### PR TITLE
docs: align samples with the 1.0 API

### DIFF
--- a/docs/api/klassy/tcommands/pagetcommand.md
+++ b/docs/api/klassy/tcommands/pagetcommand.md
@@ -9,7 +9,7 @@ using PRTelegramBot.Models.CallbackCommands;
 using PRTelegramBot.Models.Enums;
 using System.Text.Json.Serialization;
 
-namespace PRTelegramBot.Models.TCommands
+namespace PRTelegramBot.Models.CallbackCommands
 {
     /// <summary>
     /// Обработка TCommand в формате страницы.

--- a/docs/api/metody-rasshireniya/messageextension.md
+++ b/docs/api/metody-rasshireniya/messageextension.md
@@ -30,5 +30,5 @@ public static async Task AutoEditMessage(this Message message, string messageTex
 /// <param name="seconds">Через сколько секунд будет удалено сообщение.</param>
 /// <param name="botClient">Бот клиент.</param>
 /// <param name="update">Update.</param>
-public static async Task AutoEditMessageСycle(this Message message, List<string> messageTexts, int seconds, ITelegramBotClient botClient, Update update)
+public static async Task AutoEditMessageCycle(this Message message, List<string> messageTexts, int seconds, ITelegramBotClient botClient, Update update)
 ```

--- a/docs/api/utils/messageawaiter.md
+++ b/docs/api/utils/messageawaiter.md
@@ -43,7 +43,7 @@ namespace ConsoleExample.Examples
             {
                 // Симуляция тяжелой операции.
                 await Task.Delay(2000);
-                await PRTelegramBot.Helpers.Message.Send(context, $"Генерация данных завершена.");
+                await MessageSender.Send(context, $"Генерация данных завершена.");
             }
         }
     }

--- a/docs/dependency-injection/README.md
+++ b/docs/dependency-injection/README.md
@@ -85,13 +85,13 @@ public async Task Название метода(IBotContext context)
         [ReplyMenuHandler("Test")]
         public async Task TestMethod(IBotContext context)
         {
-            await PRTelegramBot.Helpers.Message.Send(context, $"{nameof(TestMethod)} {_logger != null}");
+            await MessageSender.Send(context, $"{nameof(TestMethod)} {_logger != null}");
         }
 
         [SlashHandler("/test")]
         public async Task Slash(IBotContext context)
         {
-            await PRTelegramBot.Helpers.Message.Send(context, nameof(Slash));
+            await MessageSender.Send(context, nameof(Slash));
         }
 
         [ReplyMenuHandler("inline")]
@@ -103,7 +103,7 @@ public async Task Название метода(IBotContext context)
                 new InlineCallback("TestStatic", THeader.NextPage) 
             });
             options.MenuInlineKeyboardMarkup = MenuGenerator.InlineKeyboard(menuItemns);
-            await PRTelegramBot.Helpers.Message.Send(context, nameof(InlineTest), options);
+            await MessageSender.Send(context, nameof(InlineTest), options);
         }
 
         [ReplyMenuHandler("inlinestatic")]
@@ -115,25 +115,25 @@ public async Task Название метода(IBotContext context)
                 new InlineCallback("TestStatic", THeader.NextPage)
             });
             options.MenuInlineKeyboardMarkup = MenuGenerator.InlineKeyboard(menuItemns);
-            await PRTelegramBot.Helpers.Message.Send(context, nameof(StaticInlineTest), options);
+            await MessageSender.Send(context, nameof(StaticInlineTest), options);
         }
 
         [InlineCallbackHandler&#x3C;THeader>(THeader.CurrentPage)]
         public async Task InlineHandler(IBotContext context)
         {
-            await PRTelegramBot.Helpers.Message.Send(context, nameof(InlineHandler));
+            await MessageSender.Send(context, nameof(InlineHandler));
         }
 
         [InlineCallbackHandler&#x3C;THeader>(THeader.NextPage)]
         public async static Task InlineHandlerStatic(IBotContext context)
         {
-            await PRTelegramBot.Helpers.Message.Send(context, nameof(InlineHandlerStatic));
+            await MessageSender.Send(context, nameof(InlineHandlerStatic));
         }
 
         [ReplyMenuHandler("Test1")]
         public async static Task StaticTestMethod(IBotContext context)
         {
-            await PRTelegramBot.Helpers.Message.Send(context, nameof(StaticTestMethod));
+            await MessageSender.Send(context, nameof(StaticTestMethod));
         }
     }
 }

--- a/docs/dobavlenie-i-udalenie-komand-v-dinamicheskom-rezhime.md
+++ b/docs/dobavlenie-i-udalenie-komand-v-dinamicheskom-rezhime.md
@@ -14,7 +14,7 @@ description: >-
 var method = async (IBotContext context) =>
 {
         string message = "Сообщение";
-        PRTelegramBot.Helpers.Message.Send(context, message);
+        MessageSender.Send(context, message);
 };
 ```
 

--- a/docs/fishki-poleznye-praktiki/rabota-s-komandami.md
+++ b/docs/fishki-poleznye-praktiki/rabota-s-komandami.md
@@ -15,7 +15,7 @@
 public static async Task ReplyExampleAllBots(IBotContext context)
 {
    string msg = nameof(ReplyExampleAllBots);
-   await Helpers.Message.Send(context, msg);
+   await MessageSender.Send(context, msg);
 }
 ```
 

--- a/docs/fishki-poleznye-praktiki/sozdanie-komandy-tolko-dlya-administratorov.md
+++ b/docs/fishki-poleznye-praktiki/sozdanie-komandy-tolko-dlya-administratorov.md
@@ -31,7 +31,7 @@ namespace ConsoleExample.Checkers
             {
                 var userIsAdmin = await context.IsAdmin(update.GetChatId());
                 if(!userIsAdmin)
-                    await PRTelegramBot.Helpers.Message.Send(context, "Вы не админ!");
+                    await MessageSender.Send(context, "Вы не админ!");
                 // Пользователь админ возращаем результат Passed, что позволяет выполнить метод, иначе выполнение метода будет приостановлено.
                 return userIsAdmin ? InternalCheckResult.Passed : InternalCheckResult.Custom;
             }
@@ -66,7 +66,7 @@ public static async Task AdminOnlyExample(IBotContext context)
 {
     bool isAdminUpdate = await context.IsAdmin(update);
     bool isAdminById = await context.IsAdmin(update.GetChatId());
-    await PRTelegramBot.Helpers.Message.Send(context, $"Вы администратор бота: {isAdminById} {isAdminUpdate}");
+    await MessageSender.Send(context, $"Вы администратор бота: {isAdminById} {isAdminUpdate}");
 }
 
 ```

--- a/docs/obrabotka-komand/obrabotka-inline-komand/inlinecallback-s-podtverzhdeniem.md
+++ b/docs/obrabotka-komand/obrabotka-inline-komand/inlinecallback-s-podtverzhdeniem.md
@@ -17,7 +17,7 @@
 public static async Task InlineConfirm(IBotContext context)
 {
     //Кнопка для которой нужно создать подтверждение.
-    var exampleInlineCallback = new InlineCallback<EntityTCommand<long>>("Кнопка с подтвержением", CustomTHeaderTwo.ExampleThree, new EntityTCommand<long>(3, ActionWithLastMessage.Delete));
+    var exampleInlineCallback = new InlineCallback<EntityTCommand<long>>("Кнопка с подтвержением", CustomTHeaderTwo.ExampleTwo, new EntityTCommand<long>(3, ActionWithLastMessage.Delete));
     //Обертка кнопки.
     var exampleWithConfirmation = new InlineCallbackWithConfirmation(exampleInlineCallback, ActionWithLastMessage.Delete);
 
@@ -30,7 +30,7 @@ public static async Task InlineConfirm(IBotContext context)
     option.MenuInlineKeyboardMarkup = testMenu;
     string msg = "InlineCallback с подтверждением";
     //Отправка сообщение с меню
-    await PRTelegramBot.Helpers.Message.Send(context, msg, option);
+    await MessageSender.Send(context, msg, option);
 }
 ```
 
@@ -54,7 +54,7 @@ public static async Task InlineConfirm(IBotContext context)
 public static async Task InlineConfirmWithBack(IBotContext context)
 {
     //Кнопка для которой нужно создать подтверждение.
-    var exampleInlineCallback = new InlineCallback<EntityTCommand<long>>("Кнопка с подтвержением", CustomTHeaderTwo.ExampleThree, new EntityTCommand<long>(3, ActionWithLastMessage.Delete));
+    var exampleInlineCallback = new InlineCallback<EntityTCommand<long>>("Кнопка с подтвержением", CustomTHeaderTwo.ExampleTwo, new EntityTCommand<long>(3, ActionWithLastMessage.Delete));
     //Кнопка обработчик назад или кастомная.
     var exampleBack = new InlineCallback("Назад", CustomTHeaderTwo.ExampleBack);
 
@@ -71,9 +71,9 @@ public static async Task InlineConfirmWithBack(IBotContext context)
     string msg = "InlineCallback с подтверждением и обработкой кнопки назад или кастомной";
     //Отправка сообщение с меню
     if(update.Type == Telegram.Bot.Types.Enums.UpdateType.CallbackQuery)
-        await PRTelegramBot.Helpers.Message.Edit(context, msg, option);
+        await MessageEditor.Edit(context, msg, option);
     else
-        await PRTelegramBot.Helpers.Message.Send(context, msg, option);
+        await MessageSender.Send(context, msg, option);
 }
 ```
 

--- a/docs/obrabotka-komand/obrabotka-inline-komand/obrabotka-inline-komand.md
+++ b/docs/obrabotka-komand/obrabotka-inline-komand/obrabotka-inline-komand.md
@@ -43,7 +43,7 @@ public static async Task Inline(IBotContext context)
     if (command != null)
     {
         string msg = "Выполнена команда callback";
-        await PRTelegramBot.Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 }
  
@@ -60,7 +60,7 @@ public static async Task InlineTwo(IBotContext context)
     if (command != null)
     {
         string msg = $"Идентификатор который вы передали {command.Data.EntityId}";
-        await PRTelegramBot.Helpers.Message.Send(context);
+        await MessageSender.Send(context);
     }
  
 }

--- a/docs/obrabotka-komand/obrabotka-inline-komand/sozdanie-inline-menyu.md
+++ b/docs/obrabotka-komand/obrabotka-inline-komand/sozdanie-inline-menyu.md
@@ -81,7 +81,7 @@ public class Commands
         //Передача меню в настройки
         option.MenuInlineKeyboardMarkup = testMenu;
         string msg = "Пример работы меню";
-        await PRTelegramBot.Helpers.Message.Send(context, msg, option);
+        await MessageSender.Send(context, msg, option);
     }
 }
 ```

--- a/docs/obrabotka-komand/obrabotka-slash-komand.md
+++ b/docs/obrabotka-komand/obrabotka-slash-komand.md
@@ -67,7 +67,7 @@ namespace ConsoleExample.Examples.Commands
                 "\n /get_2 - команда 2" +
                 "\n /get_3 - команда 3" +
                 "\n /get_4 - команда 4";
-            await Helpers.Message.Send(context, msg);
+            await MessageSender.Send(context, msg);
         }
 
         /// <summary>
@@ -83,20 +83,20 @@ namespace ConsoleExample.Examples.Commands
             // Нет аргументов
             if (args.Count == 0)
             {
-                await Helpers.Message.Send(context, "Команда /get");
+                await MessageSender.Send(context, "Команда /get");
                 return;
             }
 
             // Один аргумент
             if (args.Count == 1)
             {
-                await Helpers.Message.Send(context, $"Команда /get со значением: {args[0]}");
+                await MessageSender.Send(context, $"Команда /get со значением: {args[0]}");
                 return;
             }
 
             // Несколько аргументов
             string joinedArgs = string.Join(", ", args);
-            await Helpers.Message.Send(context, $"Команда /get со значениями: {joinedArgs}");
+            await MessageSender.Send(context, $"Команда /get со значениями: {joinedArgs}");
         }
 
         /// <summary>
@@ -112,20 +112,20 @@ namespace ConsoleExample.Examples.Commands
             // Нет аргументов
             if (args.Count == 0)
             {
-                await Helpers.Message.Send(context, "Команда /int");
+                await MessageSender.Send(context, "Команда /int");
                 return;
             }
 
             // Один аргумент
             if (args.Count == 1)
             {
-                await Helpers.Message.Send(context, $"Команда /int со значением: {args[0]}");
+                await MessageSender.Send(context, $"Команда /int со значением: {args[0]}");
                 return;
             }
 
             // Несколько аргументов
             string joinedArgs = string.Join(", ", args);
-            await Helpers.Message.Send(context, $"Команда /int со значениями: {joinedArgs}");
+            await MessageSender.Send(context, $"Команда /int со значениями: {joinedArgs}");
         }
 
         /// <summary>
@@ -141,20 +141,20 @@ namespace ConsoleExample.Examples.Commands
             // Нет аргументов
             if (args.Count == 0)
             {
-                await Helpers.Message.Send(context, "Команда /bool");
+                await MessageSender.Send(context, "Команда /bool");
                 return;
             }
 
             // Один аргумент
             if (args.Count == 1)
             {
-                await Helpers.Message.Send(context, $"Команда /bool со значением: {args[0]}");
+                await MessageSender.Send(context, $"Команда /bool со значением: {args[0]}");
                 return;
             }
 
             // Несколько аргументов
             string joinedArgs = string.Join(", ", args);
-            await Helpers.Message.Send(context, $"Команда /bool со значениями: {joinedArgs}");
+            await MessageSender.Send(context, $"Команда /bool со значениями: {joinedArgs}");
         }
 
         /// <summary>
@@ -169,12 +169,12 @@ namespace ConsoleExample.Examples.Commands
             if (args.Count > 0)
             {
                 string msgWithArgs = $"Команда /start со значением {args[0]}";
-                await Helpers.Message.Send(context, msgWithArgs);
+                await MessageSender.Send(context, msgWithArgs);
                 return;
             }
 
             string msg = $"Команда /start";
-            await Helpers.Message.Send(context, msg);
+            await MessageSender.Send(context, msg);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace ConsoleExample.Examples.Commands
         public static async Task ExampleSlashEqualsCommand(IBotContext context)
         {
             string msg = nameof(ExampleSlashEqualsCommand);
-            await Helpers.Message.Send(context, msg);
+            await MessageSender.Send(context, msg);
         }
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace ConsoleExample.Examples.Commands
         public static async Task ExampleSlashEqualsRegisterCommand(IBotContext context)
         {
             string msg = nameof(ExampleSlashEqualsRegisterCommand);
-            await Helpers.Message.Send(context, msg);
+            await MessageSender.Send(context, msg);
         }
     }
 }
@@ -222,7 +222,7 @@ public class Commands
     public static async Task ExampleReply(IBotContext context)
     {
         string msg = "Бот: ответ бота тест";
-        await PRTelegramBot.Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 }
 ```

--- a/docs/obrabotka-komand/obrabotka-soobshenii-polzovatelya-reply/README.md
+++ b/docs/obrabotka-komand/obrabotka-soobshenii-polzovatelya-reply/README.md
@@ -54,7 +54,7 @@ public class Commands
     public static async Task ReplyExampleOne(IBotContext context)
     {
         string msg = nameof(ReplyExampleOne);
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
     
     /// <summary>
@@ -65,7 +65,7 @@ public class Commands
     public static async Task ReplyExampleTwo(IBotContext context)
     {
         string msg = nameof(ReplyExampleTwo);
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
  
     /// <summary>
@@ -77,7 +77,7 @@ public class Commands
     public static async Task ExampleReplyMany(IBotContext context)
     {
         string msg = nameof(ExampleReplyMany);
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
  
     /// <summary>
@@ -89,7 +89,7 @@ public class Commands
     public static async Task ExampleReplyBotIdOne(IBotContext context)
     {
         string msg = nameof(ExampleReplyBotIdOne);
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
     
     /// <summary>
@@ -100,7 +100,7 @@ public class Commands
     public static async Task ReplyExampleAllBots(IBotContext context)
     {
         string msg = nameof(ReplyExampleAllBots);
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 }
 ```

--- a/docs/obrabotka-komand/obrabotka-soobshenii-polzovatelya-reply/dinamicheskie-reply-komandy-iz-json-faila.md
+++ b/docs/obrabotka-komand/obrabotka-soobshenii-polzovatelya-reply/dinamicheskie-reply-komandy-iz-json-faila.md
@@ -85,7 +85,7 @@ public static async Task ExampleReplyDynamicCommand(IBotContext context)
 	 */
 
 	string msg = nameof(ExampleReplyDynamicCommand);
-	await Helpers.Message.Send(context, msg);
+	await MessageSender.Send(context, msg);
 }
 
 ```

--- a/docs/obrabotka-komand/obrabotka-soobshenii-polzovatelya-reply/sozdanie-reply-menyu.md
+++ b/docs/obrabotka-komand/obrabotka-soobshenii-polzovatelya-reply/sozdanie-reply-menyu.md
@@ -27,7 +27,7 @@ _**Даже если вы укажите одновременно MenuReplyKeybo
 * resizeKeyboard – флаг **resize** из telegram api.
 * mainMenu – если не пустой, добавляет в конце меню пункт простой кнопки. (Например может использоваться для показа кнопки “Главное меню”).
 
-**PRTelegramBot.Helpers.Message.Send** – вспомогательный метод обертка над Telegram.Bot. Может принимать помимо самого сообщения еще и параметры с помощью OptionMessage. Так же если размер сообщения будет больше 4000 символов, разделит текст на несколько сообщений.
+**PRTelegramBot.Services.Messages.MessageSender.Send** – вспомогательный метод обертка над Telegram.Bot. Может принимать помимо самого сообщения еще и параметры с помощью OptionMessage. Так же если размер сообщения будет больше 4000 символов, разделит текст на несколько сообщений.
 
 Пример с комментариями простого меню представлен ниже
 
@@ -61,7 +61,7 @@ public static async Task ExampleReplyMenu(IBotContext context)
     var menu = MenuGenerator.ReplyKeyboard(1, menuList, true, "Главное меню");
     //Добавляем в настройки меню
     option.MenuReplyKeyboardMarkup = menu;
-    await PRTelegramBot.Helpers.Message.Send(context, msg, option);
+    await MessageSender.Send(context, msg, option);
 }
 ```
 

--- a/docs/obrabotka-komand/rabota-s-kalendarem.md
+++ b/docs/obrabotka-komand/rabota-s-kalendarem.md
@@ -62,7 +62,7 @@ public static async Task PickDate(IBotContext context)
         using (var inlineHandler = new InlineCallback&#x3C;CalendarTCommand>(botClient, update))
         {
             var command = inlineHandler.GetCommandByCallbackOrNull();
-            await Helpers.Message.Send(botClient, update, command.Data.Date.ToString());
+            await MessageSender.Send(botClient, update, command.Data.Date.ToString());
         }
     }
     catch (Exception ex)

--- a/docs/ogranichennyi-dostup-k-komandam.md
+++ b/docs/ogranichennyi-dostup-k-komandam.md
@@ -39,7 +39,7 @@ public enum UserPrivilege
 public static async Task ExampleAccess(IBotContext context)
 {
     string msg = nameof(ExampleAccess);
-    await Helpers.Message.Send(context, msg);
+    await MessageSender.Send(context, msg);
 }
 ```
 
@@ -90,7 +90,7 @@ public static async Task OnCheckPrivilege(PrivilegeEventArgs e)
 
     // Доступа нет.
     string errorMsg = "У вас нет доступа к данной функции";
-    await Helpers.Message.Send(e.Context, errorMsg);
+    await MessageSender.Send(e.Context, errorMsg);
     return;
 
 }

--- a/docs/postranichnyi-vyvod-informacii-v-soobshenie.md
+++ b/docs/postranichnyi-vyvod-informacii-v-soobshenie.md
@@ -244,7 +244,7 @@ public class ExamplePage
         var generateMenu = MenuGenerator.GetPageMenu(data.CurrentPage, data.PageCount, CustomTHeaderTwo.CustomPageHeader);
         var option = new OptionMessage();
         option.MenuInlineKeyboardMarkup = generateMenu;
-        var message = await Helpers.Message.Send(botClient, update, msg, option);
+        var message = await MessageSender.Send(botClient, update, msg, option);
     }
 
     /// <summary>
@@ -262,7 +262,7 @@ public class ExamplePage
         var option = new OptionMessage();
         option.MenuInlineKeyboardMarkup = generateMenu;
 
-        var message = await Helpers.Message.Send(botClient, update, msg, option);
+        var message = await MessageSender.Send(botClient, update, msg, option);
     }
 
     /// <summary>
@@ -304,7 +304,7 @@ public class ExamplePage
                             msg = "Нечего не найдено";
                         }
                         //Редактирую текущую страницу
-                        await Helpers.Message.Edit(context, msg, option);
+                        await MessageEditor.Edit(context, msg, option);
                     }
                     //обрабатываю данные по заголовку
                     else if (header == CustomTHeaderTwo.CustomPageHeader2)
@@ -327,7 +327,7 @@ public class ExamplePage
                             msg = "Нечего не найдено";
                         }
                         //Редактирую текущую страницу
-                        await Helpers.Message.Edit(context, msg, option);
+                        await MessageEditor.Edit(context, msg, option);
                     }
                 }
             }
@@ -367,7 +367,7 @@ public class ExamplePage
         var menu = MenuGenerator.ReplyKeyboard(1, menuList, true, "Главное меню");
         //Добавляем в настройки меню
         option.MenuReplyKeyboardMarkup = menu;
-        await Helpers.Message.Send(context, msg, option);
+        await MessageSender.Send(context, msg, option);
     }
 }
 ```

--- a/docs/rabota-s-belym-spiskom-polzovatelei.md
+++ b/docs/rabota-s-belym-spiskom-polzovatelei.md
@@ -58,7 +58,7 @@ namespace ConsoleExample.Examples
         public static async Task OnlyWhiteList(IBotContext context)
         {
             string msg = nameof(OnlyWhiteList);
-            await PRTelegramBot.Helpers.Message.Send(context, msg);
+            await MessageSender.Send(context, msg);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace ConsoleExample.Examples
         public static async Task AllUsers(IBotContext context)
         {
             string msg = nameof(AllUsers);
-            await PRTelegramBot.Helpers.Message.Send(context, msg);
+            await MessageSender.Send(context, msg);
         }
     }
 }

--- a/docs/rabota-s-keshem.md
+++ b/docs/rabota-s-keshem.md
@@ -88,7 +88,7 @@ public static async Task GetCache(IBotContext context)
     string msg = $"Запись в кэш пользователя данных: {context.GetChatId()}";
     //Записываем данные в кеш пользователя
     context.GetCacheData<UserCache>().Id = update.GetChatId();
-    await PRTelegramBot.Helpers.Message.Send(context, msg);
+    await MessageSender.Send(context, msg);
 }
  
 /// <summary>
@@ -109,7 +109,7 @@ public static async Task CheckCache(IBotContext context)
     {
         msg = $"Данные в кэше пользователя отсутствуют.";
     }
-    await PRTelegramBot.Helpers.Message.Send(context, msg);
+    await MessageSender.Send(context, msg);
 }
  
 /// <summary>
@@ -122,6 +122,6 @@ public static async Task ClearCache(IBotContext context)
     string msg = "Тестирование функции пошагового выполнения";
     //Очищаем кеш для пользователя
     context.GetCacheData<UserCache>().ClearData();
-    await PRTelegramBot.Helpers.Message.Send(context, msg);
+    await MessageSender.Send(context, msg);
 }
 ```

--- a/docs/rabota-s-poshagovymi-komandami.md
+++ b/docs/rabota-s-poshagovymi-komandami.md
@@ -222,7 +222,7 @@ public class ExampleStepCommand
         string msg = "Тестирование функции пошагового выполнения\nНапишите ваше имя";
         //Регистрация обработчика для последовательной обработки шагов и сохранение данных
         context.RegisterStepHandler(new StepTelegram(StepOne, new StepCache()));
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 
     /// <summary>
@@ -239,7 +239,7 @@ public class ExampleStepCommand
         handler!.GetCache<StepCache>().Name = update.Message.Text;
         //Регистрация следующего шага
         handler.RegisterNextStep(StepTwo);
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 
     /// <summary>
@@ -260,7 +260,7 @@ public class ExampleStepCommand
         //Добавление пустого reply меню с кнопкой "Главное меню"
         //Функция является приоритетной, если пользователь нажмет эту кнопку будет выполнена функция главного меню, а не следующего шага.
         option.MenuReplyKeyboardMarkup = MenuGenerator.ReplyKeyboard(1, new List<string>(), true, new DictionaryJSON().GetButton(nameof(ReplyKeys.RP_MAIN_MENU)));
-        await Helpers.Message.Send(context, msg, option);
+        await MessageSender.Send(context, msg, option);
     }
 
 
@@ -277,7 +277,7 @@ public class ExampleStepCommand
                      $"\nПоследовательность шагов очищена.";
         //Последний шаг
         context.ClearStepUserHandler();
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 
     /// <summary>
@@ -291,7 +291,7 @@ public class ExampleStepCommand
             ? "Следующий шаг проигнорирован" 
         : "Следующий шаг отсутствовал";
     
-        await Helpers.Message.Send(context, msg);
+        await MessageSender.Send(context, msg);
     }
 }
 ```

--- a/docs/rabota-s-sobytiyami/README.md
+++ b/docs/rabota-s-sobytiyami/README.md
@@ -227,19 +227,19 @@ namespace ConsoleExample.Examples.Events
         public static async Task OnWrongTypeChat(BotEventArgs e)
         {
             string msg = "Неверный тип чата";
-            await Helpers.Message.Send(e.Context, msg);
+            await MessageSender.Send(e.Context, msg);
         }
 
         public static async Task OnMissingCommand(BotEventArgs args)
         {
             string msg = "Не найдена команда";
-            await Helpers.Message.Send(args.Context, msg);
+            await MessageSender.Send(args.Context, msg);
         }
 
         public static async Task OnErrorCommand(BotEventArgs args)
         {
             string msg = "Произошла ошибка при обработке команды";
-            await Helpers.Message.Send(args.Context, msg);
+            await MessageSender.Send(args.Context, msg);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace ConsoleExample.Examples.Events
 
             // Доступа нет.
             string errorMsg = "У вас нет доступа к данной функции";
-            await Helpers.Message.Send(e.Context, errorMsg);
+            await MessageSender.Send(e.Context, errorMsg);
             return;
 
         }
@@ -281,12 +281,12 @@ namespace ConsoleExample.Examples.Events
         public static async Task OnUserStartWithArgs(StartEventArgs args)
         {
             string msg = "Пользователь отправил старт с аргументом";
-            await Helpers.Message.Send(args.Context, msg);
+            await MessageSender.Send(args.Context, msg);
         }
         public static async Task OnWrongTypeMessage(BotEventArgs e)
         {
             string msg = "Неверный тип сообщения";
-            await Helpers.Message.Send(e.Context, msg);
+            await MessageSender.Send(e.Context, msg);
         }
     }
 }


### PR DESCRIPTION
The documentation still taught APIs that 1.0 removed or renamed. Every code sample below would fail to compile against the 1.0 package.

## Changes

| Replacement | Call sites |
| --- | --- |
| `PRTelegramBot.Helpers.Message.Send` → `MessageSender.Send` | 61 |
| `PRTelegramBot.Helpers.Message.Edit` → `MessageEditor.Edit` | 3 |
| The same facade named in prose | 1 |
| `Models.TCommands` → `Models.CallbackCommands` | 1 |
| `AutoEditMessageСycle` → `AutoEditMessageCycle` (the old name held a Cyrillic С) | 1 |
| The confirmation sample | 2 |

The `Helpers.Message` facade was deleted in 1.0. The signatures of `MessageSender.Send` and `MessageEditor.Edit` are identical to the ones it forwarded to, so only the type name changes — no argument was touched.

## The confirmation sample

It wrapped a button under `CustomTHeaderTwo.ExampleThree`, but the handler for that header reads `EntityTCommand<string>` while the button carried `EntityTCommand<long>`. Pressing "Yes" therefore threw

```
System.Text.Json.JsonException: The JSON value could not be converted to System.String. Path: $.d.1
```

which the inline converter caught, logged and turned into `null`, so the handler quietly did nothing and the button looked broken. The sample now uses `ExampleTwo`, whose handler reads the type the button actually carries. This matches the fix already applied to `ExampleInlineConfirmation.cs` in the example project.

## Verification

- 21 files changed, 69 insertions, 69 deletions — every added line is one of the replacements above and nothing else.
- No occurrences of `Helpers.Message`, `Models.TCommands` or `AutoEditMessageСycle` remain anywhere under `docs/`.
- CRLF line endings and the absence of a BOM are preserved, matching what GitBook exported.

Two earlier suspicions turned out to be false alarms and were deliberately left alone: the `InlineButton(` hits on two API pages are `GetInlineButton(`, not the deleted type; and the `CustomTHeader.ExampleThree` sample on the inline-menu page uses a different enum that has no handler at all, so there is no type mismatch there.

## Note on GitBook

`docs/` is synced with GitBook, which is the source of truth for that directory. While this PR is open, avoid editing these 21 pages in the GitBook web editor to prevent a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
